### PR TITLE
Add ipynb exclusion to pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       entry: ufmt format
       language: python
       require_serial: true
+      exclude: "\\.ipynb"
 
     - id: flake8
       name: flake8


### PR DESCRIPTION
No one deserves to feel the pain of a black-formatted-for-python ipynb json file.