### PR TITLE
Check in pydantic tests and change the sig composition

### DIFF
--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,0 +1,324 @@
+import json
+from functools import partial
+from types import FunctionType, MethodType
+
+import pytest
+from pydantic.json import custom_pydantic_encoder
+
+from xopt.pydantic import (
+    CallableModel,
+    get_callable_from_string,
+    JSON_ENCODERS,
+    ObjLoader,
+    validate_and_compose_signature,
+)
+
+
+def misc_fn(x, y=1, *args, **kwargs):
+    pass
+
+
+class MiscClass:
+    @staticmethod
+    def misc_static_method(x, y=1, *args, **kwargs):
+        return
+
+    @classmethod
+    def misc_cls_method(cls, x, y=1, *args, **kwargs):
+        return cls
+
+    def misc_method(self, x, y=1, *args, **kwargs):
+        return
+
+
+class TestJsonEncoders:
+
+    misc_class = MiscClass()
+
+    @pytest.mark.parametrize(
+        ("fn",),
+        [
+            (misc_fn,),
+            pytest.param(misc_class.misc_method, marks=pytest.mark.xfail(strict=True)),
+            (misc_class.misc_static_method,),
+            pytest.param(
+                misc_class.misc_cls_method, marks=pytest.mark.xfail(strict=True)
+            ),
+        ],
+    )
+    def test_function_type(self, fn):
+        encoder = {FunctionType: JSON_ENCODERS[FunctionType]}
+        json_encoder = partial(custom_pydantic_encoder, encoder)
+
+        serialized = json.dumps(fn, default=json_encoder)
+        loaded = json.loads(serialized)
+        callable_from_str = get_callable_from_string(loaded)
+
+        assert fn == callable_from_str
+
+    @pytest.mark.parametrize(
+        ("fn",),
+        [
+            pytest.param(
+                misc_class.misc_static_method, marks=pytest.mark.xfail(strict=True)
+            ),
+            pytest.param(misc_fn, marks=pytest.mark.xfail(strict=True)),
+            (misc_class.misc_method,),
+            pytest.param(
+                misc_class.misc_cls_method, marks=pytest.mark.xfail(strict=True)
+            ),
+        ],
+    )
+    def test_method_type(self, fn):
+        encoder = {MethodType: JSON_ENCODERS[MethodType]}
+        json_encoder = partial(custom_pydantic_encoder, encoder)
+
+        serialized = json.dumps(fn, default=json_encoder)
+        loaded = json.loads(serialized)
+        callable = get_callable_from_string(loaded, bind=self.misc_class)
+
+        assert fn == callable
+
+    @pytest.mark.parametrize(
+        ("fn",),
+        [
+            (misc_class.misc_static_method,),
+            (misc_fn,),
+            (misc_class.misc_method,),
+            (misc_class.misc_cls_method,),
+        ],
+    )
+    def test_full_encoder(self, fn):
+        json_encoder = partial(custom_pydantic_encoder, JSON_ENCODERS)
+        serialized = json.dumps(fn, default=json_encoder)
+        loaded = json.loads(serialized)
+
+        get_callable_from_string(loaded)
+
+
+class TestSignatureValidateAndCompose:
+
+    misc_class = MiscClass()
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            pytest.param((5, 2, 1), {"x": 2}, marks=pytest.mark.xfail(strict=True)),
+            pytest.param((), ({"y": 2}), marks=pytest.mark.xfail(strict=True)),
+            pytest.param((2,), ({"x": 2}), marks=pytest.mark.xfail(strict=True)),
+            ((), ({"x": 2})),
+            ((), {}),
+        ],
+    )
+    def test_validate_kwarg_only(self, args, kwargs):
+        def run(*, x: int = 4):
+            pass
+
+        signature_model = validate_and_compose_signature(run, *args, **kwargs)
+        assert all(
+            [kwargs[kwarg] == getattr(signature_model, kwarg) for kwarg in kwargs]
+        )
+        # run
+
+        args, kwargs = signature_model.build()
+
+        run(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            pytest.param(
+                (
+                    5,
+                    3,
+                    2,
+                ),
+                {"x": 1},
+                marks=pytest.mark.xfail(strict=True),
+            ),
+            ((2, 1, 0), {}),
+            ((), {}),
+        ],
+    )
+    def test_validate_var_positional(self, args, kwargs):
+        def run(*args):
+            pass
+
+        signature_model = validate_and_compose_signature(run, *args, **kwargs)
+        args, kwargs = signature_model.build()
+        assert len(kwargs) == 0
+        assert len(args) == len(args)
+
+        # run
+        run(*args)
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            pytest.param((5,), {"x": 2}, marks=pytest.mark.xfail(strict=True)),
+            ((), {"x": 2, "y": 3}),
+            pytest.param((), {}, marks=pytest.mark.xfail(strict=True)),
+            (
+                (
+                    2,
+                    4,
+                ),
+                {},
+            ),
+            ((2,), {"y": 4, "extra": True}),
+            ((2,), {"y": 4}),
+            ((2,), {"y": 4, "z": 3}),
+        ],
+    )
+    def test_validate_full_sig(self, args, kwargs):
+        def run(x, y, z=4, *args, **kwargs):
+            pass
+
+        signature_model = validate_and_compose_signature(run, *args, **kwargs)
+        args, kwargs = signature_model.build()
+
+        # run
+        run(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            pytest.param((5, 1), {"y": 2}, marks=pytest.mark.xfail(strict=True)),
+            (
+                (
+                    2,
+                    4,
+                ),
+                {},
+            ),
+            ((5,), {"y": 2}),
+        ],
+    )
+    def test_validate_classmethod(self, args, kwargs):
+
+        signature_model = validate_and_compose_signature(
+            self.misc_class.misc_cls_method, *args, **kwargs
+        )
+        args, kwargs = signature_model.build()
+        self.misc_class.misc_cls_method(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            pytest.param((5, 1), {"y": 2}, marks=pytest.mark.xfail(strict=True)),
+            (
+                (
+                    2,
+                    4,
+                ),
+                {},
+            ),
+            ((5,), {"y": 2}),
+        ],
+    )
+    def test_validate_staticmethod(self, args, kwargs):
+
+        signature_model = validate_and_compose_signature(
+            self.misc_class.misc_static_method, *args, **kwargs
+        )
+        args, kwargs = signature_model.build()
+        self.misc_class.misc_static_method(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("args", "kwargs"),
+        [
+            pytest.param((5, 1), {"y": 2}, marks=pytest.mark.xfail(strict=True)),
+            (
+                (
+                    2,
+                    4,
+                ),
+                {},
+            ),
+            ((5,), {"y": 2}),
+        ],
+    )
+    def test_validate_bound_method(self, args, kwargs):
+
+        signature_model = validate_and_compose_signature(
+            self.misc_class.misc_method, *args, **kwargs
+        )
+
+        args, kwargs = signature_model.build()
+
+        self.misc_class.misc_method(*args, **kwargs)
+
+
+class TestCallableModel:
+
+    misc_class = MiscClass()
+
+    @pytest.mark.parametrize(
+        ("fn", "args", "kwargs"),
+        [
+            (misc_fn, (5,), {"y": 2}),
+            (misc_class.misc_cls_method, (5,), {"y": 2}),
+            (misc_class.misc_static_method, (5,), {"y": 2}),
+            pytest.param(
+                misc_class.misc_method,
+                (5,),
+                {"y": 2},
+                marks=pytest.mark.xfail(strict=True),
+            ),
+        ],
+    )
+    def test_construct_callable(self, fn, args, kwargs):
+        json_encoder = partial(custom_pydantic_encoder, JSON_ENCODERS)
+        serialized = json.dumps(fn, default=json_encoder)
+        loaded = json.loads(serialized)
+
+        callable = CallableModel(callable=loaded)
+        callable(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        ("fn", "args", "kwargs"),
+        [
+            pytest.param(misc_fn, (5,), {"y": 2}, marks=pytest.mark.xfail(strict=True)),
+            pytest.param(
+                misc_class.misc_cls_method,
+                (5,),
+                {"y": 2},
+                marks=pytest.mark.xfail(strict=True),
+            ),
+            pytest.param(
+                misc_class.misc_static_method,
+                (5,),
+                {"y": 2},
+                marks=pytest.mark.xfail(strict=True),
+            ),
+            (misc_class.misc_method, (5,), {"y": 2}),
+        ],
+    )
+    def test_bound_callables(self, fn, args, kwargs):
+        json_encoder = partial(custom_pydantic_encoder, JSON_ENCODERS)
+        serialized = json.dumps(fn, default=json_encoder)
+        loaded = json.loads(serialized)
+
+        callable = CallableModel(callable=loaded, bind=self.misc_class)
+        callable(*args, **kwargs)
+
+
+class TestObjLoader:
+
+    misc_class_loader_type = ObjLoader[MiscClass]
+
+    def test_class_loader(self):
+        loader = self.misc_class_loader_type()
+        assert loader.object_type == MiscClass
+
+    def test_load_model(self):
+        loader = self.misc_class_loader_type()
+        misc_obj = loader.load()
+        assert isinstance(misc_obj, (MiscClass,))
+
+    def test_serialize_loader(self):
+        loader = self.misc_class_loader_type()
+
+        json_encoder = partial(custom_pydantic_encoder, JSON_ENCODERS)
+        serialized = json.dumps(loader, default=json_encoder)
+        self.misc_class_loader_type.parse_raw(serialized)

--- a/xopt/pydantic.py
+++ b/xopt/pydantic.py
@@ -4,7 +4,7 @@ import logging
 from concurrent.futures import Future
 from importlib import import_module
 from types import FunctionType, MethodType
-from typing import Any, Callable, Generic, Iterable, Optional, TypeVar
+from typing import Any, Callable, Generic, Iterable, List, Optional, TypeVar
 
 import numpy as np
 from pydantic import BaseModel, create_model, Extra, Field, root_validator, validator
@@ -38,7 +38,7 @@ JSON_ENCODERS = {
 
 class CallableModel(BaseModel):
     callable: Callable
-    kwargs: BaseModel
+    signature: BaseModel
 
     class Config:
         arbitrary_types_allowed = True
@@ -74,29 +74,21 @@ class CallableModel(BaseModel):
 
         # for reloading:
         kwargs = {}
-        args = ()
+        args = []
         if "args" in values:
             args = values.pop("args")
 
         if "kwargs" in values:
-            kwargs = values["kwargs"]
+            kwargs = values.pop("kwargs")
 
-        # ignore kwarg-only and arg-only args for now
-        sig_kwargs, _, _ = validate_and_compose_signature(callable, *args, **kwargs)
+        if "signature" in values:
+            if "args" in values["signature"]:
+                args = values["signature"]["args"]
 
-        # fix for pydantic handling...
-        kwargs = {}
-        for key, value in sig_kwargs.items():
-            if isinstance(value, (tuple,)):
-                kwargs[key] = (tuple, Field(None))
+            if "kwargs" in values:
+                kwargs = values["signature"]["kwargs"]
 
-            elif value is None:
-                kwargs[key] = (Any, Field(None))
-
-            else:
-                kwargs[key] = value
-
-        values["kwargs"] = create_model(f"Kwargs_{callable.__qualname__}", **kwargs)()
+        values["signature"] = validate_and_compose_signature(callable, *args, **kwargs)
 
         return values
 
@@ -104,21 +96,9 @@ class CallableModel(BaseModel):
         if kwargs is None:
             kwargs = {}
 
-        # create self.kwarg copy
-        fn_kwargs = self.kwargs.dict()
+        fn_args, fn_kwargs = self.signature.build(*args, **kwargs)
 
-        # update pos/kw kwargs with args
-        if len(args):
-
-            stored_kwargs = list(fn_kwargs.keys())
-
-            for i, arg in enumerate(args[: len(fn_kwargs)]):
-                fn_kwargs[stored_kwargs[i]] = arg
-
-        # update stored kwargs
-        fn_kwargs.update(kwargs)
-
-        return self.callable(**fn_kwargs)
+        return self.callable(*fn_args, **fn_kwargs)
 
 
 class ObjLoader(
@@ -355,9 +335,27 @@ def get_callable_from_string(callable: str, bind: Any = None) -> Callable:
 
     try:
         module = import_module(module_name)
-    except ModuleNotFoundError as err:
-        logger.error("Unable to import module %s", module_name)
-        raise err
+
+    except ModuleNotFoundError:
+
+        try:
+            module_split = module_name.rsplit(".", 1)
+
+            if len(module_split) != 2:
+                raise ValueError(f"Unable to access: {callable}")
+
+            module_name, class_name = module_split
+
+            module = import_module(module_name)
+            callable_name = f"{class_name}.{callable_name}"
+
+        except ModuleNotFoundError as err:
+            logger.error("Unable to import module %s", module_name)
+            raise err
+
+        except ValueError as err:
+            logger.error(err)
+            raise err
 
     # construct partial in case of bound method
     if "." in callable_name:
@@ -410,25 +408,101 @@ def get_callable_from_string(callable: str, bind: Any = None) -> Callable:
     return callable
 
 
+class SignatureModel(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    def build(self, *args, **kwargs):
+        stored_kwargs = self.dict()
+
+        stored_args = []
+        if "args" in stored_kwargs:
+            stored_args = stored_kwargs.pop("args")
+
+        positional_kwargs = []
+
+        # adjust for positional
+        args = list(args)
+        if len(args) < len(stored_args):
+            stored_args[: len(args)] = args
+
+        else:
+            stored_args = args
+
+        stored_kwargs.update(kwargs)
+
+        # exclude empty parameters
+        stored_kwargs = {
+            key: value
+            for key, value in stored_kwargs.items()
+            if not isinstance(
+                value,
+                (
+                    type(
+                        inspect.Parameter.empty,
+                    )
+                ),
+            )
+        }
+
+        if len(positional_kwargs):
+            kwarg_keys = list(kwargs.keys())
+            for i, positional_kwarg in enumerate(positional_kwargs):
+
+                kwargs[kwarg_keys[i]] = positional_kwarg
+
+        return stored_args, stored_kwargs
+
+
 def validate_and_compose_signature(callable: Callable, *args, **kwargs):
     # try partial bind to validate
     signature = inspect.signature(callable)
     bound_args = signature.bind_partial(*args, **kwargs)
 
-    sig_pos_or_kw = {}
-    sig_kw_only = bound_args.arguments.get("kwargs")
-    sig_args_only = bound_args.arguments.get("args")
+    sig_kw = bound_args.arguments.get("kwargs", {})
+    sig_args = bound_args.arguments.get("args", [])
 
+    sig_kwargs = {}
     # Now go parameter by parameter and assemble kwargs
     for i, param in enumerate(signature.parameters.values()):
 
-        if param.kind == param.POSITIONAL_OR_KEYWORD:
-            sig_pos_or_kw[param.name] = (
-                param.default if not param.default == param.empty else None
-            )
+        if param.kind in [param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY]:
+            # if param not bound use default/ compose field rep
+            if not sig_kw.get(param.name):
+
+                # create a field representation
+                if param.default == param.empty:
+                    sig_kwargs[param.name] = param.empty
+
+                else:
+                    sig_kwargs[param.name] = param.default
+
+            else:
+                sig_kwargs[param.name] = sig_kw.get(param.name)
 
             # assign via binding
             if param.name in bound_args.arguments:
-                sig_pos_or_kw[param.name] = bound_args.arguments[param.name]
+                sig_kwargs[param.name] = bound_args.arguments[param.name]
 
-    return sig_pos_or_kw, sig_kw_only, sig_args_only
+    # create pydantic model
+    pydantic_fields = {"args": (List[Any], Field(list(sig_args)))}
+    for key, value in sig_kwargs.items():
+        if isinstance(value, (tuple,)):
+            pydantic_fields[key] = (tuple, Field(None))
+
+        elif value == inspect.Parameter.empty:
+            pydantic_fields[key] = (inspect.Parameter.empty, Field(value))
+
+        else:
+            # assigning empty default
+            if value is None:
+                pydantic_fields[key] = (inspect.Parameter.empty, Field(None))
+
+            else:
+                pydantic_fields[key] = value
+
+    model = create_model(
+        f"Kwargs_{callable.__qualname__}", __base__=SignatureModel, **pydantic_fields
+    )
+
+    return model()


### PR DESCRIPTION
In addition to adding pydantic tests, I changed the validate_and_compose_signature method to return a custom pydantic model for the signature. This centralized the handling. All args, kwargs, + positional or kwargs are handled in this change. 