### PR TITLE
Remove iterrows

### DIFF
--- a/xopt/evaluator.py
+++ b/xopt/evaluator.py
@@ -99,11 +99,15 @@ class Evaluator(BaseModel):
 
     def submit_data(self, input_data: pd.DataFrame):
         """submit dataframe of inputs to executor"""
-        input_data = pd.DataFrame(input_data)  # cast to dataframe
+        input_data = pd.DataFrame(input_data)  # cast to dataframe for consistency
         futures = {}
         # for index, row in input_data.iterrows(): # Bad, does not preserve dtype
-        for index, row in zip(input_data.index, input_data.to_dict(orient="records")):
-            future = self.submit(dict(row))
+        # for index, row in zip(input_data.index, input_data.to_dict(orient="records")):
+        # This should be more efficient:
+        for row in input_data.itertuples():
+            inputs = row._asdict()
+            index = inputs.pop("Index")
+            future = self.submit(inputs)
             futures[index] = future
 
         return futures

--- a/xopt/evaluator.py
+++ b/xopt/evaluator.py
@@ -101,15 +101,11 @@ class Evaluator(BaseModel):
         """submit dataframe of inputs to executor"""
         input_data = pd.DataFrame(input_data)  # cast to dataframe for consistency
         futures = {}
-        # for index, row in input_data.iterrows(): # Bad, does not preserve dtype
-        # for index, row in zip(input_data.index, input_data.to_dict(orient="records")):
-        # This should be more efficient:
+        # Do not use iterrows, it doesn't preserve dtype
         for row in input_data.itertuples():
             inputs = row._asdict()
             index = inputs.pop("Index")
-            future = self.submit(inputs)
-            futures[index] = future
-
+            futures[index] = self.submit(inputs)
         return futures
 
 

--- a/xopt/evaluator.py
+++ b/xopt/evaluator.py
@@ -42,6 +42,7 @@ class Evaluator(BaseModel):
 
     class Config:
         """config"""
+
         arbitrary_types_allowed = True
         # validate_assignment = True # Broken in 1.9.0.
         # Trying to fix in https://github.com/samuelcolvin/pydantic/pull/4194
@@ -100,7 +101,7 @@ class Evaluator(BaseModel):
         """submit dataframe of inputs to executor"""
         input_data = pd.DataFrame(input_data)  # cast to dataframe
         futures = {}
-        #for index, row in input_data.iterrows(): # Bad, does not preserve dtype
+        # for index, row in input_data.iterrows(): # Bad, does not preserve dtype
         for index, row in zip(input_data.index, input_data.to_dict(orient="records")):
             future = self.submit(dict(row))
             futures[index] = future

--- a/xopt/evaluator.py
+++ b/xopt/evaluator.py
@@ -100,7 +100,8 @@ class Evaluator(BaseModel):
         """submit dataframe of inputs to executor"""
         input_data = pd.DataFrame(input_data)  # cast to dataframe
         futures = {}
-        for index, row in input_data.iterrows():
+        #for index, row in input_data.iterrows(): # Bad, does not preserve dtype
+        for index, row in zip(input_data.index, input_data.to_dict(orient="records")):
             future = self.submit(dict(row))
             futures[index] = future
 

--- a/xopt/generators/bayesian/models/standard.py
+++ b/xopt/generators/bayesian/models/standard.py
@@ -96,9 +96,8 @@ def create_standard_model(
         )
 
         if use_conservative_prior_mean:
-            models[-1].mean_module.constant = torch.nn.Parameter(
-                torch.tensor(5.0, **tkwargs), requires_grad=False
-            )
+            models[-1].mean_module.constant.data = torch.tensor(5.0, **tkwargs)
+            models[-1].mean_module.constant.requires_grad = False
 
         mll = ExactMarginalLogLikelihood(models[-1].likelihood, models[-1])
         fit_gpytorch_model(mll)


### PR DESCRIPTION
Pandas Dataframe `iterrows()` does not preserve dtype!
https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.iterrows.html#pandas.DataFrame.iterrows

This is a possible fix with dataframe `df`:
`for index, row in df.iterrows():` -> `for index, row in zip(df.index, df.to_dict(orient="records")): `

The following should be more efficient:
```python
for named_tuple in df.itertuples():
    row = named_tuple._asdict()
    index = row.pop("Index")
```