### PR TITLE
remove itertuples and add more tests

### DIFF
--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -36,8 +36,10 @@ class TestEvaluator:
 
     def test_type_preservation(self):
         """
+        Tests for these problems:
         iterrows does not necessarily preserve types:
         https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.iterrows.html
+        itertuples does not preserve column names with understores or colons.
         """
         evaluator = Evaluator(function=self.identity)
 
@@ -46,6 +48,9 @@ class TestEvaluator:
             {
                 "ints": [1, 2, 3],
                 "floats": [2.0, 3.0, 4.0],
+                "_leading": [2.0, 3.0, 4.0],
+                "has:colon": [1, 2.0, 3],
+                ":colon:leading": [2.0, 3.0, 4.0],
                 #  Do not add these.
                 # 'strings': ['a','b','c'],
                 # 'booleans': [True, False, True],

--- a/xopt/evaluator.py
+++ b/xopt/evaluator.py
@@ -101,10 +101,9 @@ class Evaluator(BaseModel):
         """submit dataframe of inputs to executor"""
         input_data = pd.DataFrame(input_data)  # cast to dataframe for consistency
         futures = {}
-        # Do not use iterrows, it doesn't preserve dtype
-        for row in input_data.itertuples():
-            inputs = row._asdict()
-            index = inputs.pop("Index")
+        input_data.to_dict(orient="records")
+        # Do not use iterrows or itertuples.
+        for index, inputs in zip(input_data.index, input_data.to_dict("records")):
             futures[index] = self.submit(inputs)
         return futures
 

--- a/xopt/evaluator.py
+++ b/xopt/evaluator.py
@@ -101,7 +101,6 @@ class Evaluator(BaseModel):
         """submit dataframe of inputs to executor"""
         input_data = pd.DataFrame(input_data)  # cast to dataframe for consistency
         futures = {}
-        input_data.to_dict(orient="records")
         # Do not use iterrows or itertuples.
         for index, inputs in zip(input_data.index, input_data.to_dict("records")):
             futures[index] = self.submit(inputs)


### PR DESCRIPTION
Pandas Dataframe `itertuples` does not preserve `_` or `:` in column names. This pattern does:

```python
for index, row_dict in zip(df.index, df.to_dict("records")):
```

Also see: https://github.com/pandas-dev/pandas/issues/23848