### PR TITLE
Bump pydantic version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.9
   - deap
   - numpy
-  - pydantic>=1.9.0
+  - pydantic>=1.10.0
   - pyyaml
   - pytorch
   - botorch>=0.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ torch
 botorch>=0.6.5
 gpytorch
 pandas
-pydantic>=1.9.0
+pydantic>=1.10.0
 ipywidgets
 tqdm


### PR DESCRIPTION
Resolves unexplained Python 3.9 issues with not skipping executor during model serialization