### PR TITLE
Add contextual optimization generator

### DIFF
--- a/xopt/generators/bayesian/contextual.py
+++ b/xopt/generators/bayesian/contextual.py
@@ -1,0 +1,85 @@
+from abc import ABC
+from typing import Dict, List
+
+import pandas as pd
+import torch
+from botorch.acquisition import FixedFeatureAcquisitionFunction
+
+from xopt.errors import XoptError
+from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
+from xopt.generators.bayesian.models.contextual_model import ContextualModelOptions
+from xopt.generators.bayesian.options import BayesianOptions
+from xopt.generators.bayesian.upper_confidence_bound import (
+    UCBOptions,
+    UpperConfidenceBoundGenerator,
+)
+from xopt.utils import format_option_descriptions
+from xopt.vocs import VOCS
+
+
+class ContextualOptions(BayesianOptions):
+    model = ContextualModelOptions()
+
+
+class ContextualBayesianGenerator(BayesianGenerator, ABC):
+    def __init__(self, vocs: VOCS, options: BayesianOptions = None):
+        options = options or BayesianOptions()
+        if not isinstance(options, BayesianOptions):
+            raise ValueError("options must be a TDOptions object")
+
+        super().__init__(vocs, options)
+        self.target_prediction_time = None
+
+    def get_input_data(self, data: pd.DataFrame):
+        return torch.tensor(
+            data[self.vocs.variable_names + ["context"]].to_numpy(), **self._tkwargs
+        )
+
+    def generate(self, n_candidates: int) -> List[Dict]:
+        output = super().generate(n_candidates)
+        return output
+
+    def get_acquisition(self, model):
+        acq = super().get_acquisition(model)
+        # use the latest context assuming that context varies slowly
+        latest_context = self.data[["context"]].to_numpy()[-1]
+        # get context variables
+        len_context = len(latest_context)
+        column = list(range(-len_context, 0))
+        value = torch.tensor(latest_context, **self._tkwargs).unsqueeze(0)
+        fixed_acq = FixedFeatureAcquisitionFunction(
+            acq, self.vocs.n_variables + len_context, column, value
+        )
+        return fixed_acq
+
+    def _get_initial_batch_points(self, bounds):
+        if self.options.optim.use_nearby_initial_points:
+            raise XoptError(
+                "nearby initial points not implemented for " "contextual optimization"
+            )
+        else:
+            batch_initial_points = None
+            raw_samples = self.options.optim.raw_samples
+        return batch_initial_points, raw_samples
+
+
+class ContextualUCBOptions(UCBOptions, ContextualOptions):
+    model = ContextualModelOptions()
+
+
+class ContextualUpperConfidenceBoundGenerator(
+    ContextualBayesianGenerator, UpperConfidenceBoundGenerator
+):
+    alias = "time_dependent_upper_confidence_bound"
+    __doc__ = (
+        """Implements Time-Dependent Bayeisan Optimization using the Upper
+            Confidence Bound acquisition function"""
+        + f"{format_option_descriptions(UCBOptions())}"
+    )
+
+    def __init__(self, vocs: VOCS, options: ContextualUCBOptions = None):
+        options = options or ContextualUCBOptions()
+        if not type(options) is ContextualUCBOptions:
+            raise ValueError("options must be a ContextualUCBOptions object")
+
+        super(UpperConfidenceBoundGenerator, self).__init__(vocs, options)

--- a/xopt/generators/bayesian/models/contextual_model.py
+++ b/xopt/generators/bayesian/models/contextual_model.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+import torch
+from botorch.models import ModelListGP
+from botorch.models.transforms import Normalize
+
+from xopt.generators.bayesian.models.standard import StandardModelConstructor
+from xopt.generators.bayesian.options import ModelOptions
+from xopt.vocs import VOCS
+
+
+class ContextualModelOptions(ModelOptions):
+    name: str = "contextual_standard"
+
+
+class ContextualModelConstructor(StandardModelConstructor):
+    def __init__(self, vocs: VOCS, options: ContextualModelOptions):
+        if not type(options) is ContextualModelOptions:
+            raise ValueError("options must be a ContextualModelOptions object")
+        super().__init__(vocs, options)
+
+    def build_model(self, data: pd.DataFrame, tkwargs: dict = None) -> ModelListGP:
+        self.tkwargs = tkwargs or {"dtype": torch.double, "device": "cpu"}
+        self.collect_data(data)
+
+        # add time column to variable data
+        self.input_data = pd.concat([self.input_data, data["context"]], axis=1)
+
+        # add bounds for input transformation
+        bounds = np.hstack(
+            [
+                self.vocs.bounds,
+                np.array(
+                    (
+                        data["context"].to_numpy().min(),
+                        data["context"].to_numpy().max(),
+                    )
+                ).reshape(2, -1),
+            ]
+        )
+
+        self.input_transform = Normalize(
+            self.vocs.n_variables + 1, bounds=torch.tensor(bounds, **tkwargs)
+        )
+        self.input_transform.to(**tkwargs)
+
+        return self.build_standard_model()

--- a/xopt/generators/bayesian/models/utils.py
+++ b/xopt/generators/bayesian/models/utils.py
@@ -1,3 +1,4 @@
+from xopt.generators.bayesian.models.contextual_model import ContextualModelConstructor
 from xopt.generators.bayesian.models.standard import StandardModelConstructor
 from xopt.generators.bayesian.models.time_dependent import TimeDependentModelConstructor
 from xopt.generators.bayesian.models.trainable_mean import TrainableMeanModelConstructor
@@ -14,6 +15,8 @@ def get_model_constructor(model_options):
             constructor = TimeDependentModelConstructor
         elif name == "trainable_mean_standard":
             constructor = TrainableMeanModelConstructor
+        elif name == "contextual_standard":
+            constructor = ContextualModelConstructor
         else:
             raise ValueError(f"{name} is not a vaild model name")
 


### PR DESCRIPTION
This PR implements a basic contextual BO version using the `FixedFeatureAcquisitionFunction`.

For now, it works very similarly to the `time_dependent` generator, with some differences:

- It relies on the `evaluator` to return data with an additional key `context` with context variables.
- It takes the context variables from the last observation to calculate the acquisition. Although not ideal, this is sufficient for slowly-varying context variables

However, it would be nice if one can tweak a bit the `Xopt.step()` so that the actual contextual information could be passed to the `generate` for suggesting the next sample, making it more robust for a longer pause/ sudden change of the machine condition, etc. (somewhat like the idea in #78 )

I could add proper tests & an example notebook once we decide if #78 will be implemented or we keep it this way.