### PR TITLE
ENH: Untility method to copy generator objects

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,8 @@
 from unittest import TestCase
-from unittest.mock import patch
 
 import torch
 from pydantic import BaseModel, Extra
 from torch import nn
-from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
 from xopt.resources.testing import TEST_VOCS_BASE, TEST_VOCS_DATA
 from xopt.utils import add_constraint_information, copy_generator, has_device_field
 
@@ -45,8 +43,8 @@ class TestUtils(TestCase):
     def test_has_device_field(self):
         module = MockModule()
 
-        # Check if has_device_field returns True for device "cpu" (which exists in the module)
+        # Check if has_device_field returns True for device "cpu" (which is in the module)
         assert has_device_field(module, torch.device("cpu")) is True
 
-        # Check if has_device_field returns False for device "cuda" (which does not exist in the module)
+        # Check if has_device_field returns False for device "cuda" (which is not in the module)
         assert has_device_field(module, torch.device("cuda")) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,52 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+import torch
+from pydantic import BaseModel, Extra
+from torch import nn
+from xopt.generators.bayesian.bayesian_generator import BayesianGenerator
 from xopt.resources.testing import TEST_VOCS_BASE, TEST_VOCS_DATA
-from xopt.utils import add_constraint_information
+from xopt.utils import add_constraint_information, copy_generator, has_device_field
+
+BaseModel.Config.arbitrary_types_allowed = True
+BaseModel.Config.extra = Extra.forbid
 
 
-class TestUtils:
+class MockBaseModel(BaseModel):
+    device: torch.device
+
+
+class MockModule(nn.Module):
+    def __init__(self):
+        super(MockModule, self).__init__()
+        self.param1 = nn.Parameter(torch.randn(5))
+        self.param2 = nn.Parameter(torch.randn(5).to("cpu"))
+        self.buffer1 = nn.Parameter(torch.randn(5))
+        self.buffer2 = nn.Parameter(torch.randn(5).to("cpu"))
+
+
+class TestUtils(TestCase):
     def test_get_constraint_info(self):
         add_constraint_information(TEST_VOCS_DATA, TEST_VOCS_BASE)
+
+    def test_copy_generator(self):
+        generator = MockBaseModel(device=torch.device("cuda"))
+        generator_copy, list_of_fields_on_gpu = copy_generator(generator)
+
+        # Check if generator_copy is a deepcopy of generator
+        assert generator_copy is not generator
+        assert isinstance(generator_copy, MockBaseModel)
+        assert generator_copy.device.type == "cuda"
+
+        # Check if list_of_fields_on_gpu contains the correct fields
+        assert len(list_of_fields_on_gpu) == 1
+        assert list_of_fields_on_gpu[0] == "MockBaseModel"
+
+    def test_has_device_field(self):
+        module = MockModule()
+
+        # Check if has_device_field returns True for device "cpu" (which exists in the module)
+        assert has_device_field(module, torch.device("cpu")) is True
+
+        # Check if has_device_field returns False for device "cuda" (which does not exist in the module)
+        assert has_device_field(module, torch.device("cuda")) is False

--- a/xopt/utils.py
+++ b/xopt/utils.py
@@ -170,7 +170,6 @@ def copy_generator(generator: Type[Generator]) -> Type[Generator]:
     generator_copy : Generator
     list_of_fields_on_gpu : list[str]
     """
-
     generator_copy = deepcopy(generator)
     generator_copy_dict = generator_copy.dict()
     list_of_fields_on_gpu = []

--- a/xopt/utils.py
+++ b/xopt/utils.py
@@ -5,7 +5,7 @@ import sys
 import time
 import traceback
 from copy import deepcopy
-from typing import Type
+from typing import List, Tuple, Type
 
 import pandas as pd
 import torch
@@ -155,7 +155,7 @@ def format_option_descriptions(options_object):
     return "\n\nGenerator Options\n" + yaml.dump(options_dict)
 
 
-def copy_generator(generator: Type[Generator]) -> Type[Generator]:
+def copy_generator(generator: Type[Generator]) -> Tuple[Type[Generator], List[str]]:
     """
     Create a deep copy of a given generator.
     Moves any data saved on the gpu in the deepcopy of the generator to the cpu.

--- a/xopt/utils.py
+++ b/xopt/utils.py
@@ -196,7 +196,7 @@ def recursive_move_data_gpu_to_cpu(
     pydantic_object_dict = pydantic_object.dict()
     list_of_fields_on_gpu = [pydantic_object.__class__.__name__]
 
-    for field_name, field_value in pydantic_object.items():
+    for field_name, field_value in pydantic_object_dict.items():
         if isinstance(field_value, BaseModel):
             result = recursive_move_data_gpu_to_cpu(field_value)
             pydantic_object_dict[field_name] = result[0]

--- a/xopt/utils.py
+++ b/xopt/utils.py
@@ -181,9 +181,8 @@ def copy_generator(generator: ModelMetaclass) -> Type[ModelMetaclass]:
                 list_of_fields_on_gpu.append(field_name)
         elif isinstance(field_value, torch.nn.Module):
             if has_device_field(field_value, torch.device("cuda")):
-                if field_value.device.type == "cuda":
-                    generator_copy_dict[field_name] = field_value.cpu()
-                    list_of_fields_on_gpu.append(field_name)
+                generator_copy_dict[field_name] = field_value.cpu()
+                list_of_fields_on_gpu.append(field_name)
 
     return generator_copy, list_of_fields_on_gpu
 

--- a/xopt/utils.py
+++ b/xopt/utils.py
@@ -5,12 +5,14 @@ import sys
 import time
 import traceback
 from copy import deepcopy
+from typing import Type
 
 import pandas as pd
 import torch
 import yaml
 from pydantic import BaseModel
 
+from xopt.generator import Generator
 from .pydantic import get_descriptions_defaults
 from .vocs import VOCS
 
@@ -153,7 +155,7 @@ def format_option_descriptions(options_object):
     return "\n\nGenerator Options\n" + yaml.dump(options_dict)
 
 
-def copy_generator(generator: BaseModel) -> BaseModel:
+def copy_generator(generator: Type[Generator]) -> Type[Generator]:
     """
     Create a deep copy of a given generator.
     Moves any data saved on the gpu in the deepcopy of the generator to the cpu.


### PR DESCRIPTION
## Description
This PR adds a method to create a deep copy of a generator object. This method will also move any data saved on the gpu in the copied object to the cpu for torch.Tensor and torch.nn.Module objects.   

## Motivation and Context
The intention of this method it to make it easy to save the current state of the generator at a given step.

## How Has This Been Tested?
Unit tests for the new methods were added 

## Where Has This Been Documented?
The method has a comment describing itself at the top of the method which should be added by the auto documentation. 