### PR TITLE
Delete print statement for validation of GP constructor

### DIFF
--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -93,7 +93,6 @@ class BayesianGenerator(Generator, ABC):
 
     @field_validator("gp_constructor", mode="before")
     def validate_gp_constructor(cls, value):
-        print(f"Verifying model {value}")
         constructor_dict = {"standard": StandardModelConstructor}
         if value is None:
             value = StandardModelConstructor()


### PR DESCRIPTION
Deletes a print statement called during validation of the GP constructor.