### PR TITLE
BLD: fix test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 pytest
-pytest - cov
+pytest-cov
 flake8


### PR DESCRIPTION
The `test-requirements.txt` file does not appear to be in use at this point.

However, it currently contains a typo of the `pytest-cov` package, meaning it wouldn't install properly as-is.