### PR TITLE
Fix CNSGA population selection

### DIFF
--- a/tests/generators/ga/test_cnsga.py
+++ b/tests/generators/ga/test_cnsga.py
@@ -1,5 +1,6 @@
-import numpy as np
 from random import random
+
+import numpy as np
 
 from xopt.base import Xopt
 from xopt.evaluator import Evaluator
@@ -18,12 +19,10 @@ def test_cnsga():
 
 
 def test_cnsga_baddf():
-    raise_prob = 0.0
+    # Test that bad dataframes are handled ok
 
     def eval_f(x):
-        # if random() < raise_prob:
-        #    raise ValueError('bad x1')
-        return {'y1': random(), 'y2': random(), 'c1': random(), 'c2': random()}
+        return {"y1": random(), "y2": random(), "c1": random(), "c2": random()}
 
     X = Xopt(
         generator=CNSGAGenerator(vocs=tnk_vocs, population_size=32),
@@ -33,8 +32,6 @@ def test_cnsga_baddf():
     )
 
     X.random_evaluate(12)
-
-    raise_prob = 0.1
 
     for i in range(100):
         new_samples = X.generator.generate(1)
@@ -50,7 +47,6 @@ def test_cnsga_baddf():
 
     assert len(X.generator.population) == 32
 
-    # Add bad data with repeated indices
     for i in range(10):
         X.generator.generate(20)
         bad_df = X.data.iloc[np.random.randint(0, 200, 20), :].copy()

--- a/xopt/generators/ga/cnsga.py
+++ b/xopt/generators/ga/cnsga.py
@@ -292,7 +292,6 @@ def pop_from_data(data, vocs):
     """
     Return a list of DEAP deap_creator.Individual from a dataframe
     """
-    ix = data.index.to_numpy()
     v = vocs.variable_data(data).to_numpy()
     o = vocs.objective_data(data).to_numpy()
     c = vocs.constraint_data(data).to_numpy()
@@ -303,7 +302,7 @@ def pop_from_data(data, vocs):
         if c.size:
             ind.fitness.cvalues = tuple(c[i, :])
 
-        ind.index = ix[i]
+        ind.index = i
 
     return pop
 
@@ -317,7 +316,7 @@ def cnsga_select(data, n, vocs, toolbox):
     """
     pop = pop_from_data(data, vocs)
     selected = toolbox.select(pop, n)  # Order(n^2)
-    return data.loc[[ind.index for ind in selected]]
+    return data.iloc[[ind.index for ind in selected]]
 
 
 def cnsga_variation(


### PR DESCRIPTION
As reported by a user, in rare cases of repeat dataframe indices, CNSGA population can grow out of control because the next generation is selected via .loc method that can match multiple rows per value. This PR switches selection to use positional indexing.