### PR TITLE
Resolving TypeError caused by using GPU and max_travel_distances in Generator

### DIFF
--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -692,9 +692,9 @@ class BayesianGenerator(Generator, ABC):
         lengths = self.vocs.bounds[1, :] - self.vocs.bounds[0, :]
 
         # get maximum travel distances
-        max_travel_distances = (
-            torch.tensor(self.max_travel_distances, **self._tkwargs) * lengths
-        )
+        max_travel_distances = torch.tensor(
+            self.max_travel_distances, **self._tkwargs
+        ) * torch.tensor(lengths, **self._tkwargs)
         max_travel_bounds = torch.stack(
             (last_point - max_travel_distances, last_point + max_travel_distances)
         )


### PR DESCRIPTION
Fix for `TypeError` raised when specifying `max_travel_distances` and `use_cuda=True` in Generator:
```
Traceback (most recent call last):
  File "/home/data-generation/src/main.py", line 156, in <module>
    X.step()  # in this step we should only get 1
  File "/home/data-generation/venv/lib64/python3.9/site-packages/xopt/base.py", line 241, in step
    new_samples = self.generator.generate(n_generate)
  File "/home/data-generation/venv/lib64/python3.9/site-packages/xopt/generators/bayesian/bayesian_generator.py", line 320, in generate
    candidates = self.propose_candidates(model, n_candidates=n_candidates)
  File "/home/data-generation/venv/lib64/python3.9/site-packages/xopt/generators/bayesian/bayesian_generator.py", line 407, in propose_candidates
    bounds = self._get_optimization_bounds()
  File "/home/data-generation/venv/lib64/python3.9/site-packages/xopt/generators/bayesian/bayesian_generator.py", line 622, in _get_optimization_bounds
    max_travel_bounds = self._get_max_travel_distances_region(bounds)
  File "/home/data-generation/venv/lib64/python3.9/site-packages/xopt/generators/bayesian/bayesian_generator.py", line 696, in _get_max_travel_distances_region
    torch.tensor(self.max_travel_distances, **self._tkwargs) * lengths
  File "/home/data-generation/venv/lib64/python3.9/site-packages/torch/_tensor.py", line 1030, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```