### PR TITLE
Fix constants not propagating in AsynchronousXopt

### DIFF
--- a/tests/test_vocs.py
+++ b/tests/test_vocs.py
@@ -149,7 +149,7 @@ class TestVOCS(object):
             vocs.convert_dataframe_to_inputs(test_data)
 
         res = vocs.convert_dataframe_to_inputs(test_data[vocs.variable_names])
-        assert "cnt1" in res
+        assert "constant1" in res
 
     def test_validate_input_data(self):
         test_vocs = deepcopy(TEST_VOCS_BASE)

--- a/tests/test_xopt.py
+++ b/tests/test_xopt.py
@@ -208,7 +208,7 @@ class TestXopt:
         xopt = Xopt(generator=generator, evaluator=evaluator, vocs=test_vocs)
 
         test_vocs.variables = {"x2": [0, 1]}
-        test_vocs.constants["x1"] =  2.0
+        test_vocs.constants["x1"] = 2.0
 
         out = xopt.evaluate({"x2": 0.2})
         assert isinstance(out, dict)

--- a/tests/test_xopt.py
+++ b/tests/test_xopt.py
@@ -208,7 +208,7 @@ class TestXopt:
         xopt = Xopt(generator=generator, evaluator=evaluator, vocs=test_vocs)
 
         test_vocs.variables = {"x2": [0, 1]}
-        test_vocs.constants = {"x1": 2.0}
+        test_vocs.constants["x1"] =  2.0
 
         out = xopt.evaluate({"x2": 0.2})
         assert isinstance(out, dict)
@@ -259,7 +259,7 @@ class TestXopt:
         val = str(xopt)
         assert "Data size: 2" in val
         assert (
-            "vocs:\n  constants:\n    cnt1: 1.0\n  constraints:\n    c1:\n    - "
+            "vocs:\n  constants:\n    constant1: 1.0\n  constraints:\n    c1:\n    - "
             "GREATER_THAN\n    - 0.5\n  objectives:\n" in val
         )
 

--- a/xopt/asynchronous.py
+++ b/xopt/asynchronous.py
@@ -69,6 +69,10 @@ class AsynchronousXopt(Xopt):
         """
         input_data = pd.DataFrame(input_data, copy=True)  # copy for reindexing
 
+        # add constants to input data
+        for name, value in self.vocs.constants.items():
+            input_data[name] = value
+
         # Reindex input dataframe
         input_data.index = np.arange(
             self._ix_last + 1, self._ix_last + 1 + len(input_data)

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -329,7 +329,6 @@ class Xopt(XoptBaseModel):
 
         output_data = self.evaluator.evaluate_data(input_data)
 
-
         if self.strict:
             validate_outputs(output_data)
 

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -329,6 +329,7 @@ class Xopt(XoptBaseModel):
 
         output_data = self.evaluator.evaluate_data(input_data)
 
+
         if self.strict:
             validate_outputs(output_data)
 

--- a/xopt/generators/bayesian/visualize.py
+++ b/xopt/generators/bayesian/visualize.py
@@ -252,10 +252,15 @@ def visualize_generator_model(
                     x_axis, predictions["acq"][0], "C0--", label="Base Acq. Function"
                 )
                 ax[len(output_names)].plot(
-                    x_axis, predictions["acq"][1], "C0-", label="Constrained Acq. Function"
+                    x_axis,
+                    predictions["acq"][1],
+                    "C0-",
+                    label="Constrained Acq. Function",
                 )
                 ax[len(output_names)].legend()
-            ax[len(output_names)].set_ylabel(r"$\alpha\,$[{}]".format(vocs.output_names[0]))
+            ax[len(output_names)].set_ylabel(
+                r"$\alpha\,$[{}]".format(vocs.output_names[0])
+            )
         # feasibility
         if show_feasibility:
             ax[-1].plot(x_axis, predictions["feasibility"], "C0-")

--- a/xopt/resources/testing.py
+++ b/xopt/resources/testing.py
@@ -61,5 +61,5 @@ vocs:
         c1: [GREATER_THAN, 0]
         c2: ['LESS_THAN', 0.5]
     constants:
-        constant1: 1   
+        constant1: 1
 """

--- a/xopt/resources/testing.py
+++ b/xopt/resources/testing.py
@@ -61,7 +61,5 @@ vocs:
         c1: [GREATER_THAN, 0]
         c2: ['LESS_THAN', 0.5]
     constants:
-        constant1: 1
-
-        
+        constant1: 1   
 """

--- a/xopt/resources/testing.py
+++ b/xopt/resources/testing.py
@@ -9,6 +9,8 @@ def xtest_callable(input_dict: dict, a=0) -> dict:
     x1 = input_dict["x1"]
     x2 = input_dict["x2"]
 
+    assert "constant1" in input_dict
+
     y1 = x2
     c1 = x1
     return {"y1": y1, "c1": c1}
@@ -19,7 +21,7 @@ TEST_VOCS_BASE = VOCS(
         "variables": {"x1": [0, 1.0], "x2": [0, 10.0]},
         "objectives": {"y1": "MINIMIZE"},
         "constraints": {"c1": ["GREATER_THAN", 0.5]},
-        "constants": {"cnt1": 1.0},
+        "constants": {"constant1": 1.0},
     }
 )
 
@@ -27,6 +29,7 @@ cnames = (
     list(TEST_VOCS_BASE.variables.keys())
     + list(TEST_VOCS_BASE.objectives.keys())
     + list(TEST_VOCS_BASE.constraints.keys())
+    + list(TEST_VOCS_BASE.constants.keys())
 )
 
 # TODO: figure out why having the range from 0->1 or 0->10 breaks objective test data
@@ -34,7 +37,7 @@ cnames = (
 test_init_data = {
     "x1": np.linspace(0.01, 1.0, 10),
     "x2": np.linspace(0.01, 1.0, 10) * 10.0,
-    "cnt1": 1.0,
+    "constant1": 1.0,
 }
 test_init_data.update(xtest_callable(test_init_data))
 
@@ -57,4 +60,8 @@ vocs:
     constraints:
         c1: [GREATER_THAN, 0]
         c2: ['LESS_THAN', 0.5]
+    constants:
+        constant1: 1
+
+        
 """


### PR DESCRIPTION
This addresses #195 by adding constants to the inputs prepared in `AsynchronousXopt`. This also modifies the tests. 