### PR TITLE
Include requirement botorch<=0.10.0 for compatibility with python 3.9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy
   - pydantic>=2.3
   - pyyaml
-  - botorch>=0.9.2
+  - botorch>=0.9.2,<=0.10.0
   - scipy>=1.10.1
   - pandas
   - ipywidgets

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ deap
 numpy
 pyyaml
 torch
-botorch>=0.9.2
+botorch>=0.9.2,<=0.10.0
 gpytorch
 pandas
 pydantic>=2.3


### PR DESCRIPTION
We will maintain Xopt compatibility with Python 3.9.19 by restricting BoTorch version to <=0.10.0.
Once prod can support Python>=3.10, we will update the code for compatibility with BoTorch>=0.11.0.